### PR TITLE
Add audit report, tasks, editor settings, ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ cython_debug/
 *.pdf
 *.tar.gz
 *.swp
+audit-tmp/
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+    "cSpell.words": [
+        "Acworth",
+        "austell",
+        "civicclerk",
+        "civicplus",
+        "cobblinc",
+        "cutover",
+        "Datasette",
+        "getaffinity",
+        "Gotenberg",
+        "Healthchecks",
+        "homelab",
+        "Kennesaw",
+        "Laserfiche",
+        "Laserfische",
+        "legistar",
+        "Mableton",
+        "Meilisearch",
+        "muni",
+        "novusagenda",
+        "ntfy",
+        "powdersprings",
+        "sched",
+        "Sophicity",
+        "Tesseract",
+        "Tika",
+        "Typesense",
+        "webapi"
+    ]
+}

--- a/AUDIT.md
+++ b/AUDIT.md
@@ -1,0 +1,114 @@
+# Scraper Audit — Live-Site Run
+
+**Run date:** 2026-04-30
+**Methodology:** each scraper module's HTTP entry points and a representative file URL were exercised against the live vendor site and graded against the verification checklist in [TASKS.md](TASKS.md). The `__main__.py` CLI was not used (it `sys.exit()`s on non-posix at [__main__.py:60](src/cobb_tracker/__main__.py#L60)); endpoints were exercised directly with `curl` and module logic was reproduced in Python against the saved responses. Selenium-driven NovusAgenda was checked statically only (requires Linux + `sudo docker run`).
+
+## Verdict matrix
+
+| Module | Vendor | HTTP OK | Listing parses | Coverage current | Date parse | PDF serves | Verdict |
+|---|---|---|---|---|---|---|---|
+| [civicplus.py](src/cobb_tracker/municipalities/civicplus.py) — Cobb | CivicClerk | ✅ 200 | ✅ | ✅ | ✅ | ✅ %PDF-1.4 | **OK** |
+| [civicplus.py](src/cobb_tracker/municipalities/civicplus.py) — Kennesaw | CivicClerk | ✅ 200 | ✅ | ✅ | ✅ | ✅ (same backend) | **OK** |
+| [acworth.py](src/cobb_tracker/municipalities/acworth.py) | IQM2 | ✅ 200 | ✅ | ❌ frozen at end of 2024 | ✅ | ✅ %PDF-1.7 (historic) | **Stale — missing all 2025/2026** |
+| [marietta.py](src/cobb_tracker/municipalities/marietta.py) | CivicPlus AgendaCenter | ✅ 200 | ✅ | ✅ | ✅ | ✅ %PDF-1.6 | **OK** |
+| [smyrna.py](src/cobb_tracker/municipalities/smyrna.py) | PrimeGov | ✅ 200 | ✅ | ✅ | ✅ | ✅ %PDF-1.7 | **OK** |
+| [austell.py](src/cobb_tracker/municipalities/austell.py) | Sophicity → Municode (migrated) | ✅ 200 | ❌ on current page | ❌ | n/a | n/a | **Broken — vendor migrated** |
+| [powdersprings.py](src/cobb_tracker/municipalities/powdersprings.py) | CivicPlus Archive Center | ⚠️ 301 to new domain | ✅ via follow | ✅ | ✅ | ✅ %PDF-1.7 (via redirect) | **Working but on borrowed time** |
+| [novusagenda.py](src/cobb_tracker/municipalities/novusagenda.py) | NovusAgenda | ✅ 200 | not exercised (Selenium) | unknown | n/a | n/a | **Cannot run on Windows; static checks pass** |
+
+---
+
+## Per-module findings
+
+### Cobb / Kennesaw — `civicplus.py` (CivicClerk)
+
+- `GET https://cobbcoga.api.civicclerk.com/v1/Events/` → **HTTP 200**, `application/json` (OData), 56.8 KB.
+- `GET https://kennesawga.api.civicclerk.com/v1/Events/` → **HTTP 200**, 59.2 KB.
+- Both return 15 events on page 1 with a valid `@odata.nextLink` for pagination. Pagination loop in [civicplus.py:38-49](src/cobb_tracker/municipalities/civicplus.py#L38-L49) still applies.
+- File-type counts on Cobb page 1: `Agenda: 14, Agenda Packet: 15, Minutes: 12`. Kennesaw page 1: `Agenda: 15, Agenda Packet: 15, Minutes: 14`. Module currently filters only `type == "Minutes"` ([civicplus.py:70](src/cobb_tracker/municipalities/civicplus.py#L70)) — confirming TASKS.md item to extend ingestion to agendas/packets is straightforward here (the data is already in `publishedFiles`).
+- Spot-checked Cobb Minutes file (fileId=180) → `application/pdf`, magic `%PDF-1.4`, 1.13 MB.
+- `categoryName` is populated on every event sampled; the `try/except` fallback to `"misc"` at [civicplus.py:58-63](src/cobb_tracker/municipalities/civicplus.py#L58-L63) was not triggered.
+- **Note** — Sam mentioned Cobb is split across two storage backends. Only one host (`cobbcoga.api.civicclerk.com`) is wired into the module; if the second host carries records the first does not, those are silently missing. Catalogue task in TASKS.md is the right next step.
+
+### Acworth — `acworth.py` (IQM2)
+
+**This module is fetching nothing for 2025 or 2026.**
+
+- `GET https://acworthcityga.iqm2.com//api/Agency/StartupData` → **HTTP 200** (the doubled slash is harmless but should be cleaned up at [acworth.py:11-15](src/cobb_tracker/municipalities/acworth.py#L11-L15)).
+- `MeetingRanges` returned: `[2024, 2023, …, 2006]` — **no 2025 entry, no 2026 entry**. Plus the `Recent` bucket (ID=1) which the scraper deliberately skips at [acworth.py:46-48](src/cobb_tracker/municipalities/acworth.py#L46-L48).
+- `GET /api/Meeting?Range=2025&Group=70/` → **HTTP 200** with body `[]`. Same for `Range=1`. So 2025/2026 records are not hidden under "Recent" either — IQM2 simply has no current Acworth content.
+- 2024 still works: `Range=2024&Group=70` returns 103 meetings with 62 Minutes attached. Spot-checked one PDF (Type=15&ID=2115) → `application/pdf`, `%PDF-1.7`, 124 KB.
+- **What this means.** The IQM2 platform appears to be the abandoned half of the platform-cutover Sam flagged. Historical pulls 2006–2024 are intact; ongoing scrapes produce 0 new docs per run. This is exactly the kind of silent failure the audit was meant to catch.
+- 12 meeting groups exist; only one (`Group=70`) was probed. The empty-2025 finding is unlikely to differ across groups but isn't proven for all 12.
+
+### Marietta — `marietta.py` (CivicPlus AgendaCenter)
+
+- `GET https://www.mariettaga.gov/AgendaCenter` → **HTTP 200**, 316 KB.
+- 8 `<div class="listing listingCollapse noHeader">` containers found (Board of Lights and Water, Board of Zoning Appeals, City Council, …). Each has the expected `<h2 tabindex="0">`, `<table summary="List of Agendas">` with a digit-suffixed id, and `<ul class="years">`.
+- Year list on each container: `['2026', '2025', '2024', 'View More', '2023', '2022', '2021', '2020']`. The non-numeric `View More` entry is correctly filtered by `is_year` at [marietta.py:159-169](src/cobb_tracker/municipalities/marietta.py#L159-L169).
+- `POST /AgendaCenter/UpdateCategoryList` with `{year:'2024', catID:'7'}` → **HTTP 200**, 108 KB, 135 rows (`tr.catAgendaRow`). Every row has both a meeting title and a minutes link.
+- 2026 POST returns rows but `minutes_href` is `None` for them (minutes not yet published). Module handles this correctly via `if minutes_link:` at [marietta.py:127](src/cobb_tracker/municipalities/marietta.py#L127).
+- Date parsing from filename slice (`_12192024-2636` → `2024-12-19`) at [marietta.py:54-60](src/cobb_tracker/municipalities/marietta.py#L54-L60) still produces correct dates against the live data.
+- Spot-checked PDF: `application/pdf`, `%PDF-1.6`, 259 KB.
+
+### Smyrna — `smyrna.py` (PrimeGov)
+
+- `GET https://smyrnaga.primegov.com/api/v2/PublicPortal/ListArchivedMeetings?year=2026` → **HTTP 200**, JSON array of 47 events.
+- Document templates seen across 2026: `Action Summary`, `Agenda`, `HTML Agenda`, `Minutes`, `Notice of Cancellation`, `Packet`. **27 Minutes docs already published for 2026.**
+- This directly confirms the TASKS.md item — the same JSON exposes Agenda, Packet, and HTML Agenda alongside Minutes, so dropping the `templateName == "Minutes"` filter at [smyrna.py:65](src/cobb_tracker/municipalities/smyrna.py#L65) and keying off the template name as the doc-type is a one-line change to multi-doc ingestion.
+- Date parse `"Jan 05, 2026"` → `2026-01-05` works.
+- Title-cleanup regex chain at [smyrna.py:46-53](src/cobb_tracker/municipalities/smyrna.py#L46-L53) was applied to a sample title `'Planning and Zoning Meeting - A. Max Bacon City Hall - Council Chambers'` and reduced cleanly without nuking the entire title.
+- Spot-checked Minutes URL (templateId=7677) → `application/pdf`, `%PDF-1.7`, 159 KB. **The CompiledDocument endpoint 302-redirects to a temporary signed Azure Blob URL** (`pgwest.blob.core.windows.net/...?sv=…&sig=…&st=2026-04-29T13:37:10Z&se=2026-05-01T13:37:10Z`). The signed URL is good for ~2 days from issue. `requests.Session` follows the redirect inline so this is fine — but we should never persist the resolved blob URL anywhere (the signature expires).
+
+### Austell — `austell.py` (Sophicity → Municode Meetings, **migrated**)
+
+**Broken: vendor migration is the root cause.**
+
+- `GET https://www.austellga.gov/AgendasandMinutes.aspx` → **HTTP 200** but the page no longer contains a `Minutes` `<h3>`. The `mcms_RendererContentDetail` div is present but its only useful content is a button-link reading **"Click here to view CURRENT Agenda and Minutes"** pointing at `https://austell-ga.municodemeetings.com/`. Austell migrated to Municode Meetings.
+- The `Minutes` h3 detection at [austell.py:42-45](src/cobb_tracker/municipalities/austell.py#L42-L45) returns `[]` for the current page → loop over `minutes_divs` is a no-op → no current minutes scraped. No exception, no log line, just a silent zero.
+- The "past" page (`PastAgendasandMinutes.aspx`) still has the legacy structure (15 alternating `Agendas` / `Minutes` h3 sections plus 6 trailing `Minutes`-only blocks). So the scraper continues to pull historical data, but everything new lives on Municode.
+- `GET https://austell-ga.municodemeetings.com/` → **HTTP 200**, 70 KB HTML — the new site is reachable but unsupported by the codebase.
+- Sophicity is essentially dead for Austell going forward. Either add a Municode Meetings module (new vendor: Municode lists this product publicly) or wait until the broader Paperless rewrite and start fresh there.
+
+### Powder Springs — `powdersprings.py` (CivicPlus Archive Center, **domain migrated**)
+
+**Working today only because `requests` follows 301s.**
+
+- `GET https://cityofpowdersprings.org/Archive.aspx` → **HTTP 200** after **2 redirects** to `https://www.powderspringsga.gov/Archive.aspx`. The city has rebranded its primary domain from `cityofpowdersprings.org` to `powderspringsga.gov`.
+- All hardcoded constants in [powdersprings.py:27-30](src/cobb_tracker/municipalities/powdersprings.py#L27-L30) point at the legacy domain. `requests.Session.get` follows 301s by default, so the parser keeps working.
+- Archive Details table is still present with 15 `<select id="amidDDN##">` and matching `<label for=…>` pairs — group extraction at [powdersprings.py:67-72](src/cobb_tracker/municipalities/powdersprings.py#L67-L72) still works.
+- `archive` spans on inner pages still carry date-bearing names (`'April 6, 2026  '`, `'March 16, 2026  '`). `get_year` regex matches the `MMM DD, YYYY` form on these — date-fallback path is not triggered for current data.
+- `GET https://cityofpowdersprings.org/ArchiveCenter/ViewFile/Item/4709` → 301 → `https://www.powderspringsga.gov/...` → **HTTP 200**, `application/pdf`, `%PDF-1.7`, 132 KB.
+- **Risk:** the city can drop the legacy redirect at any time. Move all four constants to `https://www.powderspringsga.gov/` now.
+
+### NovusAgenda Kennesaw — `novusagenda.py` (legacy)
+
+- `GET https://kennesaw.novusagenda.com/agendapublic` → **HTTP 200** after 1 redirect (trailing-slash normalization), 84.5 KB. Title `<title>NovusAGENDA</title>`.
+- Expected element IDs (`ddlDateRange`, `SearchAgendasMeetings`, `radGridMeetings`) are all present in the static HTML.
+- **Could not actually run.** Module hard-codes `sudo docker run …/selenium/standalone-chrome` ([novusagenda.py:65-105](src/cobb_tracker/municipalities/novusagenda.py#L65-L105)) and exits on Windows. So nothing past page-load was exercised this run.
+- TASKS.md already flags this module as possibly obsolete (Kennesaw migrated to CivicClerk). The CivicClerk Kennesaw run above pulled 14 Minutes on page 1 alone, so the live source is fine without it. Decision needed: delete or rewrite for the era this can still cover.
+
+---
+
+## Cross-cutting findings
+
+1. **Silent zero is the most common failure mode.** Acworth (post-2024) and Austell (current page) both produce empty result sets without raising or logging anything. The audit checklist's "Empty result set is *real*, not a parser miss" criterion catches both. Worth wiring a per-run sanity check ("0 new docs from a jurisdiction that historically averaged N/month → log a warning") before the Paperless rewrite, since regressions only get more expensive once we're shipping into a real document store.
+2. **Vendor migrations are the leading cause of breakage.** Austell (Sophicity→Municode), Powder Springs (legacy domain → new domain), Acworth (IQM2 → ?). The domain catalogue task in TASKS.md A is the highest-leverage thing to do next.
+3. **Multi-doc data is already on the wire for 3 of 5 working modules.** CivicClerk (Cobb/Kennesaw) and PrimeGov (Smyrna) already return Agenda/Packet/Minutes side-by-side; the scrapers throw away two thirds of it. Marietta would also benefit but requires a different selector path. Smyrna is the cheapest to extend.
+4. **Random-key date fallback was not exercised** in any working module on this run. Powder Springs current-data dates all matched the regex on the first pass; no spell-correct or per-page deep-dive was triggered. Confirms TASKS.md note that the fallback only fires on legacy oddities.
+5. **All sampled file URLs returned real PDFs.** Five spot-checks across four vendors: Content-Type was always `application/pdf` and the body started with `%PDF-1.x`. No HTML-with-200 silent failures observed today.
+6. **Acworth's BASE_URL has a stray `//`**. Cosmetic but worth a one-line fix at [acworth.py:11-15](src/cobb_tracker/municipalities/acworth.py#L11-L15).
+
+## Recommended actions (delta vs. TASKS.md)
+
+These are the items the audit *concretely escalates* — not new tasks, just sharper priority:
+
+1. **Acworth migration** (new) — IQM2 is no longer the source of truth. Identify which of the 4 active Acworth domains hosts current minutes, add a module for it. Until then, the scraper produces 0 new Acworth docs per run.
+2. **Austell migration** (new) — Build a Municode Meetings adapter (new vendor, currently unrepresented in the codebase) targeting `austell-ga.municodemeetings.com`. The current scraper covers only pre-migration history.
+3. **Powder Springs domain swap** (small, do now) — replace the four constants in [powdersprings.py:27-30](src/cobb_tracker/municipalities/powdersprings.py#L27-L30) with `https://www.powderspringsga.gov/`. One-line risk reduction.
+4. **Smyrna multi-doc** (smallest unlock for the agendas/packets goal) — drop the `templateName == "Minutes"` filter at [smyrna.py:65](src/cobb_tracker/municipalities/smyrna.py#L65) and key off `templateName` as the doc-type tag. Already-flagged in TASKS.md; this audit confirms the data is there for 2026.
+5. **Sanity-check guardrail** — log a warning when a module that historically returned >0 docs returns 0. Would have surfaced Acworth and Austell automatically.
+
+## Raw artefacts
+
+Saved fetch responses are in `audit-tmp/` (gitignored — not committed). Each scraper's main listing endpoint plus one PDF spot-check is captured.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,100 @@
+# Cobb Tracker — Remaining Work
+
+## Direction shift
+
+The repo's role is changing:
+
+- **cobb-tracker** = scraper + metadata pipeline only.
+- **Paperless-ngx** = document store, OCR, FTS, tagging.
+- **New thin frontend** = citizen-facing search UI on top of Paperless.
+
+Today the repo only ingests **minutes**, OCRs them with Tesseract into SQLite, and serves the result with Datasette. The OCR/SQLite/Datasette layer goes away once Paperless is in place. Scope of ingestion expands to **agendas + agenda packets + minutes** for Cobb County and every city in it.
+
+## Scraper — current state per module
+
+Last live-site audit: **2026-04-30** ([AUDIT.md](AUDIT.md)).
+
+| Module | Vendor | Status | Notes |
+|---|---|---|---|
+| [civicplus.py](src/cobb_tracker/municipalities/civicplus.py) (Cobb, Kennesaw) | **CivicClerk** (misnamed in code) | OK (verified 2026-04-30) | Cobb is split across two storage backends per the domain migration — only `cobbcoga.api.civicclerk.com` was probed; the other backend is still uncatalogued. CivicClerk's `publishedFiles` already exposes Agenda + Agenda Packet alongside Minutes — module currently throws those away. |
+| [acworth.py](src/cobb_tracker/municipalities/acworth.py) | **IQM2** | **Broken — 0 new docs since 2024-12-31** | IQM2 `MeetingRanges` ends at 2024; `Range=2025` and the `Recent` bucket both return `[]`. Historic 2006–2024 still pulls correctly. Acworth has 4 active domains and 2 platform cutover dates — IQM2 is the abandoned half. Module needs to be repointed (or replaced) to whichever platform now hosts current minutes. |
+| [marietta.py](src/cobb_tracker/municipalities/marietta.py) | **CivicPlus AgendaCenter** | OK (verified 2026-04-30) | Year-by-year POST against `UpdateCategoryList`. 8 containers, `is_year` correctly filters the `View More` entry, 2024 City Council pulls 135 rows all with minutes URLs. |
+| [smyrna.py](src/cobb_tracker/municipalities/smyrna.py) | **PrimeGov** | OK (verified 2026-04-30) | Heavy regex cleanup of clerk-authored titles. Smyrna's full 2013→present history is in PrimeGov with agendas + minutes attached; the 2013 floor at [smyrna.py:32](src/cobb_tracker/municipalities/smyrna.py#L32) matches the actual data edge (year=2012 returns an empty array). The old Legistar deployment at `webapi.legistar.com/v1/SmyrnaCity/` is abandoned (last event 2022-12-19) — superseded by PrimeGov, don't scrape it. PrimeGov serves PDFs via short-lived signed Azure Blob URLs (~2 day TTL) — never persist the resolved blob URL. |
+| [austell.py](src/cobb_tracker/municipalities/austell.py) | **Sophicity → Municode Meetings (migrated)** | **Broken — vendor migration** | The current page (`AgendasandMinutes.aspx`) no longer contains a `Minutes` `<h3>` — it now just links out to `https://austell-ga.municodemeetings.com/`. Parser silently returns `[]` for current data. Past page still has the legacy structure, so historical pulls keep working. Need a Municode Meetings adapter (new vendor, currently unrepresented). |
+| [powdersprings.py](src/cobb_tracker/municipalities/powdersprings.py) | **CivicPlus Archive Center** | Working via 301 — domain migrated | `cityofpowdersprings.org` 301-redirects to `www.powderspringsga.gov`; module's hardcoded constants still point at the legacy domain and are working only because `requests.Session` follows redirects. Selectors and date parsing all still match. The brittle date-regex + spell-correct fallback was not exercised against current data on the audit run. |
+| [novusagenda.py](src/cobb_tracker/municipalities/novusagenda.py) (Kennesaw legacy) | **NovusAgenda** | Not portable | Hard-coded `sudo docker run` for Selenium; possibly obsolete if Kennesaw fully cut over to CivicClerk. CivicClerk Kennesaw audit pulled 14 Minutes on page 1 — the live source is fine without NovusAgenda. Static page-load passes (expected element IDs present); Selenium path was not exercised this audit (Windows). |
+| (none) | **Municode Meetings** | Missing | New vendor surfaced by Austell's migration. Confirm host (`austell-ga.municodemeetings.com`) and any other Cobb-county jurisdictions on the same platform. |
+| (none) | **Legistar** | Missing | Sam listed it as one of five active vendors. Smyrna had a Legistar deployment but migrated to PrimeGov with all records intact — Smyrna is *not* the target. Which jurisdiction Sam meant is still TBD. |
+| (none) | **Laserfische WebLink** | Documented gap | Needs session-walking pseudo-filesystem. Only confirmed in-scope use is pre-2013 Smyrna, and only if that era is actually in scope. |
+| (none) | **Mableton** | Missing | New city (incorporated 2022); not yet scraped. |
+
+## Tasks
+
+### A. Scraper audit & repair
+
+- [x] Run each module against the live site, record what still works (HTTP errors, parser breakage, empty result sets). Done 2026-04-30 — see [AUDIT.md](AUDIT.md).
+- [ ] **Repoint Acworth.** IQM2 froze at end of 2024 (0 new docs in 2025/2026). Identify which of Acworth's 4 active domains hosts current minutes and either retarget [acworth.py](src/cobb_tracker/municipalities/acworth.py) or write a new module. Until then, Acworth contributes nothing to ongoing scrapes.
+- [ ] **Add a Municode Meetings adapter for Austell.** Sophicity is dead for current Austell content; new vendor host is `https://austell-ga.municodemeetings.com/`. Existing [austell.py](src/cobb_tracker/municipalities/austell.py) only covers pre-migration history.
+- [ ] **Update Powder Springs constants** at [powdersprings.py:27-30](src/cobb_tracker/municipalities/powdersprings.py#L27-L30) from `https://cityofpowdersprings.org/` to `https://www.powderspringsga.gov/`. One-line risk reduction — works today only because `requests` follows the legacy 301.
+- [ ] Catalogue the actual vendor + URL set per jurisdiction — especially Acworth's 4 domains and Cobb's 2 storage backends. Audit only probed one Cobb backend (`cobbcoga.api.civicclerk.com`); the second is still uncatalogued.
+- [ ] Rename [civicplus.py](src/cobb_tracker/municipalities/civicplus.py) → `civicclerk.py`. The `CivicPlus` class talks to the CivicClerk API, not the AgendaCenter platform Marietta uses. The naming drift is a future bug magnet.
+- [ ] Extend every scraper to pull **agendas** and **agenda packets**, not just minutes. Today [file_ops.py:56](src/cobb_tracker/file_ops.py#L56) hard-codes `{date}-{file_type}.pdf` and every scraper sets `file_type = "minutes"`; [pdf_parse.py:125](src/cobb_tracker/pdf_parse.py#L125) strips `-minutes.pdf` to derive the date — both assumptions need to go. **Smyrna is the cheapest unlock** (audit-confirmed): every PrimeGov event already exposes Agenda + Packet + HTML Agenda + Minutes in `documentList`; just stop filtering on `templateName == "Minutes"` at [smyrna.py:65](src/cobb_tracker/municipalities/smyrna.py#L65) and key off the template name as the doc-type. CivicClerk (Cobb/Kennesaw) similarly returns `Agenda` / `Agenda Packet` / `Minutes` in the same `publishedFiles` array.
+- [ ] **Sanity-check guardrail.** Log a warning when a module that historically returned >0 docs returns 0 in a run. Acworth and Austell both failed silently this audit; this would have caught both automatically.
+- [ ] Clean up the doubled `//` in [acworth.py:11-15](src/cobb_tracker/municipalities/acworth.py#L11-L15) (cosmetic — request still works).
+- [ ] Add **Mableton** (vendor TBD).
+- [ ] Decide whether to revive NovusAgenda Kennesaw scraping. If yes, replace `sudo docker run` with a sidecar Selenium service or migrate to Playwright. (Audit suggests this is moot — CivicClerk Kennesaw covers current minutes.)
+- [ ] Add **Laserfische WebLink** support if any in-scope jurisdiction uses it.
+- [ ] Add **Legistar** support for whichever jurisdiction Sam noted.
+- [ ] Replace the random `unknownNNN` date fallback in [string_ops.py:13](src/cobb_tracker/string_ops.py#L13) with a "needs review" queue — silent random keys are how docs get lost.
+- [ ] Standardize the `file_urls` dict shape across scrapers (today each module hand-rolls it).
+
+### B. Pipeline rewrite for Paperless-ngx
+
+- [ ] Replace the SQLite + Tesseract sink with a **Paperless-ngx push** via `POST /api/documents/post_document/`.
+- [ ] Map cobb-tracker metadata → Paperless concepts:
+  - `municipality` → Correspondent
+  - `body` / `meeting_name` → Tag
+  - `file_type` (agenda / packet / minutes) → Document Type
+  - `date` → `created`
+  - source URL → custom field (permalink back to source site)
+- [ ] Keep the existing SHA-256 checksum behavior in [file_ops.py:82](src/cobb_tracker/file_ops.py#L82) for client-side dedupe; resolve duplicates against Paperless before POSTing so its rejection logs stay clean.
+- [ ] Handle the **mixed-format agenda packets** Sam flagged. Options: pre-split the packet, normalize embedded DOCX/PPTX to PDF via headless LibreOffice, then submit either as one merged PDF with bookmarks or as separate Paperless docs in a group. Pick one.
+- [ ] Delete the [pdf_parse.py](src/cobb_tracker/pdf_parse.py) Tesseract/SQLite path once Paperless is the OCR layer. Keep [file_ops.py](src/cobb_tracker/file_ops.py) for download + checksum, but route output to either a Paperless **consume** folder or the API directly (pick one — don't run both).
+- [ ] Drop the `os.name != "posix"` guard in [__main__.py:60](src/cobb_tracker/__main__.py#L60) so contributors on Windows/macOS can run scrapers.
+
+### C. Citizen-facing frontend
+
+- [ ] Spec v1 UX. Assumed baseline: single search box → results list with snippet + jurisdiction + body + date + link to source PDF, plus facets for municipality / body / document type / date range.
+- [ ] Backend choice: call the Paperless API directly from a thin SvelteKit/Next.js app, **or** mirror Paperless content into a dedicated search index (Meilisearch / Typesense). Direct API is simpler; a dedicated index is faster and hides the Paperless admin surface from the public.
+- [ ] Stable permalink scheme (e.g. `/doc/<municipality>/<body>/<date>`).
+- [ ] Public read with no login. Confirm Paperless can serve read-only documents publicly without exposing the admin UI (or terminate that at the frontend).
+
+### D. Deployment & ops (k3s homelab + Hetzner)
+
+- [ ] Helm chart / manifests for Paperless-ngx + Postgres + Redis + Tika + Gotenberg.
+- [ ] Cobb-tracker scrapers as one `CronJob` per jurisdiction (so a single broken scraper doesn't block the others).
+- [ ] PVCs for the consume folder and Paperless media.
+- [ ] Backup strategy (Paperless DB + media) — Hetzner as offsite target.
+- [ ] Failure notifications somewhere visible (Healthchecks.io / ntfy). The previous deployment "went offline a while" with no one noticing.
+- [ ] [.github/workflows/build.yml](.github/workflows/build.yml) only builds on tag push and uses deprecated actions (`upload-artifact@v1`, `Gr1N/setup-poetry@v8`). Add scraper smoke tests + lint on PR; refresh action versions.
+
+### E. Code quality / tech debt
+
+- [ ] **No tests exist.** Add HTML-fixture-based unit tests per scraper so vendor markup changes get caught at PR time, not months later in prod.
+- [ ] CLI logic in [__main__.py:111-132](src/cobb_tracker/__main__.py#L111-L132) is incoherent: `--pull-all-cities` is `store_true`, so the `is None` checks are dead code, and "no flag = scrape everything" happens via the trailing `if args.municipality is None: choose_muni("all", config)`. Either intentional and undocumented, or a bug.
+- [ ] [pdf_parse.py:128](src/cobb_tracker/pdf_parse.py#L128) builds SQL via f-string. Low risk today since input is a hex digest, but replace with a parameterized query.
+- [ ] [file_ops.py:62](src/cobb_tracker/file_ops.py#L62) uses module-level `requests.get` instead of the pooled `self.session` it was passed.
+- [ ] `os.sched_getaffinity(0)` in [pdf_parse.py:33](src/cobb_tracker/pdf_parse.py#L33) is Linux-only — breaks macOS even today. Moot if E.B retires this file, but worth noting.
+
+## Open questions
+
+These block sections B and C — would like answers before sinking time into them.
+
+1. **Existing corpus.** Is there a backup of the database/files from Sam's last working deployment? If yes, we ingest that into Paperless rather than re-scraping years of history.
+2. **Mableton in scope?** And which platform is it on?
+3. **Legistar / Laserfische** — which jurisdictions specifically? (Confirmed *not* Smyrna: its Legistar history was migrated into PrimeGov, and Laserfiche only matters for pre-2013 Smyrna if that era is in scope.)
+4. **Agenda packets.** Pre-split on our side, or preserve the original composite in Paperless and accept the OCR limitations?
+5. **Frontend scope for v1.** Just search + filters + results? Or also saved searches / email alerts / RSS for keywords (e.g. someone subscribes to "cobblinc")?
+6. **Auth model.** Fully public read, no login? Or gated for early users?
+7. **Hosting split.** Frontend on Hetzner with Paperless + scrapers in the homelab over a tunnel? Or all in Hetzner? Or all in homelab with Hetzner as failover only?
+8. **Parallel raw-text store.** Replace SQLite/Datasette entirely with Paperless, or keep cobb-tracker's DB as a parallel raw-text store for the kind of bulk-text queries Paperless's UI is bad at?


### PR DESCRIPTION
- Add a live-site scraper audit (AUDIT.md) and accompanying TASKS.md to document findings and next steps (run date 2026-04-30). 
- Add VS Code cSpell custom word list (.vscode/settings.json) to reduce noise for known vendor/project terms. 
- Update .gitignore to exclude audit-tmp/ (saved fetches) and local Claude settings (.claude/settings.local.json). 

These changes add project documentation and developer tooling while preventing temporary audit artifacts and local settings from being committed.